### PR TITLE
feat: add global watch-config support for telegraf sidecars

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	goruntime "runtime"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -81,6 +82,7 @@ func main() {
 	var telegrafRequestsMemory string
 	var telegrafLimitsCPU string
 	var telegrafLimitsMemory string
+	var telegrafWatchConfig string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -112,6 +114,8 @@ func main() {
 		"Default memory limits for the telegraf sidecar.")
 	flag.StringVar(&telegrafSecretNamePrefix, "telegraf-secret-name-prefix", defaultTelegrafSecretNamePrefix,
 		"Set the telegraf configuration secret name prefix, defaults to 'telegraf-config'")
+	flag.StringVar(&telegrafWatchConfig, "telegraf-watch-config", "",
+		"Enable telegraf --watch-config flag. Valid values: 'inotify', 'poll'. Default: disabled")
 
 	opts := zap.Options{
 		Development: true,
@@ -144,6 +148,11 @@ func main() {
 		telegrafLimitsMemory,
 	}); err != nil {
 		setupLog.Error(err, "failed to validate telegraf resource flag values")
+		os.Exit(1)
+	}
+
+	if err := validateWatchConfig(telegrafWatchConfig); err != nil {
+		setupLog.Error(err, "failed to validate telegraf watch-config flag value")
 		os.Exit(1)
 	}
 
@@ -204,6 +213,7 @@ func main() {
 		LimitsCPU:            telegrafLimitsCPU,
 		LimitsMemory:         telegrafLimitsMemory,
 		EnableNativeSidecars: enableNativeSidecars,
+		WatchConfig:          telegrafWatchConfig,
 	}
 
 	if err = admission.SetupWithManager(mgr); err != nil {
@@ -240,4 +250,22 @@ func validateRequestsAndLimits(resources []string) error {
 	}
 
 	return nil
+}
+
+func validateWatchConfig(watchConfig string) error {
+	if watchConfig == "" {
+		return nil // empty is valid (disabled)
+	}
+
+	// Trim whitespace and convert to lowercase for case-insensitive comparison
+	watchConfig = strings.ToLower(strings.TrimSpace(watchConfig))
+
+	validValues := []string{"inotify", "poll"}
+	for _, valid := range validValues {
+		if watchConfig == valid {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid watch-config value '%s', valid values are: %v", watchConfig, validValues)
 }

--- a/internal/injectorwebhook/injector.go
+++ b/internal/injectorwebhook/injector.go
@@ -39,6 +39,7 @@ type SidecarInjector struct {
 	LimitsCPU            string
 	LimitsMemory         string
 	EnableNativeSidecars bool
+	WatchConfig          string
 }
 
 //+kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=ignore,groups=core,resources=pods,verbs=create;update,versions=v1,name=telegraf.mickey.dev,sideEffects=none,admissionReviewVersions=v1

--- a/internal/injectorwebhook/injector_test.go
+++ b/internal/injectorwebhook/injector_test.go
@@ -511,6 +511,106 @@ var _ = Describe("Sidecar injector webhook", func() {
 
 				cleanUpPod(pod.GetName())
 			})
+
+			It("Should include --watch-config inotify when WatchConfig is set to 'inotify'", func() {
+				oldVal := injector.WatchConfig
+				injector.WatchConfig = "inotify"
+				podName := "sidecar-watch-config-inotify"
+
+				pod := newTestPod(podName, map[string]string{
+					metadata.TelegrafConfigClassAnnotation: "default",
+				})
+				Expect(k8sClient.Create(testCtx, pod)).To(Succeed())
+
+				pod = &corev1.Pod{}
+				lookupKey := types.NamespacedName{Name: podName, Namespace: namespace}
+				Expect(k8sClient.Get(testCtx, lookupKey, pod)).To(Succeed())
+
+				var found bool
+				for _, container := range pod.Spec.Containers {
+					if container.Name == containerName {
+						found = true
+						expectedCmd := []string{
+							"telegraf",
+							"--config",
+							"/etc/telegraf/telegraf.conf",
+							"--watch-config",
+							"inotify",
+						}
+						Expect(container.Command).To(Equal(expectedCmd))
+					}
+				}
+				Expect(found).To(BeTrue())
+
+				cleanUpPod(pod.GetName())
+				injector.WatchConfig = oldVal
+			})
+
+			It("Should include --watch-config poll when WatchConfig is set to 'poll'", func() {
+				oldVal := injector.WatchConfig
+				injector.WatchConfig = "poll"
+				podName := "sidecar-watch-config-poll"
+
+				pod := newTestPod(podName, map[string]string{
+					metadata.TelegrafConfigClassAnnotation: "default",
+				})
+				Expect(k8sClient.Create(testCtx, pod)).To(Succeed())
+
+				pod = &corev1.Pod{}
+				lookupKey := types.NamespacedName{Name: podName, Namespace: namespace}
+				Expect(k8sClient.Get(testCtx, lookupKey, pod)).To(Succeed())
+
+				var found bool
+				for _, container := range pod.Spec.Containers {
+					if container.Name == containerName {
+						found = true
+						expectedCmd := []string{
+							"telegraf",
+							"--config",
+							"/etc/telegraf/telegraf.conf",
+							"--watch-config",
+							"poll",
+						}
+						Expect(container.Command).To(Equal(expectedCmd))
+					}
+				}
+				Expect(found).To(BeTrue())
+
+				cleanUpPod(pod.GetName())
+				injector.WatchConfig = oldVal
+			})
+
+			It("Should not include --watch-config when WatchConfig is empty", func() {
+				oldVal := injector.WatchConfig
+				injector.WatchConfig = ""
+				podName := "sidecar-no-watch-config"
+
+				pod := newTestPod(podName, map[string]string{
+					metadata.TelegrafConfigClassAnnotation: "default",
+				})
+				Expect(k8sClient.Create(testCtx, pod)).To(Succeed())
+
+				pod = &corev1.Pod{}
+				lookupKey := types.NamespacedName{Name: podName, Namespace: namespace}
+				Expect(k8sClient.Get(testCtx, lookupKey, pod)).To(Succeed())
+
+				var found bool
+				for _, container := range pod.Spec.Containers {
+					if container.Name == containerName {
+						found = true
+						expectedCmd := []string{
+							"telegraf",
+							"--config",
+							"/etc/telegraf/telegraf.conf",
+						}
+						Expect(container.Command).To(Equal(expectedCmd))
+					}
+				}
+				Expect(found).To(BeTrue())
+
+				cleanUpPod(pod.GetName())
+				injector.WatchConfig = oldVal
+			})
 		})
 	})
 })

--- a/internal/injectorwebhook/sidecar.go
+++ b/internal/injectorwebhook/sidecar.go
@@ -46,13 +46,15 @@ type containerConfig struct {
 	env            []corev1.EnvVar
 	envFrom        []corev1.EnvFromSource
 	volumeMounts   []corev1.VolumeMount
+	watchConfig    string
 }
 
 func newContainerConfig(ctx context.Context, s *SidecarInjector, podName string) (*containerConfig, error) {
 	var err error
 	c := &containerConfig{
-		image: s.TelegrafImage,
-		log:   logf.FromContext(ctx, "pod", podName).WithName("sidecar"),
+		image:       s.TelegrafImage,
+		log:         logf.FromContext(ctx, "pod", podName).WithName("sidecar"),
+		watchConfig: s.WatchConfig,
 	}
 
 	// Setup default environment variables for the sidecar
@@ -247,14 +249,22 @@ func (c *containerConfig) applyAnnotationOverrides(annotations map[string]string
 }
 
 func (c *containerConfig) buildContainerSpec() corev1.Container {
+	// Build telegraf command with optional --watch-config flag
+	cmd := []string{
+		"telegraf",
+		"--config",
+		"/etc/telegraf/telegraf.conf",
+	}
+
+	// Add --watch-config flag if configured
+	if c.watchConfig != "" {
+		cmd = append(cmd, "--watch-config", c.watchConfig)
+	}
+
 	container := corev1.Container{
-		Name:  containerName,
-		Image: c.image,
-		Command: []string{
-			"telegraf",
-			"--config",
-			"/etc/telegraf/telegraf.conf",
-		},
+		Name:    containerName,
+		Image:   c.image,
+		Command: cmd,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    c.requestsCPU,


### PR DESCRIPTION
Add --telegraf-watch-config flag to enable telegraf's --watch-config functionality globally across all injected sidecar containers.

- Add CLI flag with validation for 'inotify'/'poll' values
- Update sidecar container command to include --watch-config when enabled
- Add unit tests for watch-config functionality

Allows platform operators to enable immediate config reloading when telegraf configuration changes, improving config update latency compared to manual restarts.