### PR TITLE
feat: add security context configuration for telegraf sidecars

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,13 +38,14 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/config"
+	ctrlCfg "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/jmickey/telegraf-sidecar-operator/internal/classdata"
+	"github.com/jmickey/telegraf-sidecar-operator/internal/config"
 	"github.com/jmickey/telegraf-sidecar-operator/internal/controller"
 	"github.com/jmickey/telegraf-sidecar-operator/internal/injectorwebhook"
 	"github.com/jmickey/telegraf-sidecar-operator/internal/metadata"
@@ -90,6 +91,13 @@ func main() {
 	var telegrafLimitsCPU string
 	var telegrafLimitsMemory string
 	var telegrafWatchConfig string
+	var telegrafSecurityRunAsUser config.OptionalInt64
+	var telegrafSecurityRunAsGroup config.OptionalInt64
+	var telegrafSecurityRunAsNonRoot config.OptionalBool
+	var telegrafSecurityReadOnlyRootFS config.OptionalBool
+	var telegrafSecurityAllowPrivEsc config.OptionalBool
+	var telegrafSecurityCapAdd string
+	var telegrafSecurityCapDrop string
 	var disableCacheOptimizations bool
 	var leaderElectLeaseDuration time.Duration
 	var leaderElectRenewDeadline time.Duration
@@ -110,7 +118,7 @@ func main() {
 	flag.DurationVar(&leaderElectRetryPeriod, "leader-elect-retry-period", 5*time.Second,
 		"Duration the LeaderElector clients should wait between tries of actions. "+
 			"Lower values provide faster failover but increase API server load.")
-	flag.BoolVar(&leaderElectReleaseOnCancel, "leader-elect-retry-period", true,
+	flag.BoolVar(&leaderElectReleaseOnCancel, "leader-elect-release-on-cancel", true,
 		"Defines if the leader should step down voluntarily on controller manager shutdown.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", false,
 		"If set the metrics endpoint is served securely")
@@ -139,6 +147,20 @@ func main() {
 		"Set the telegraf configuration secret name prefix, defaults to 'telegraf-config'")
 	flag.StringVar(&telegrafWatchConfig, "telegraf-watch-config", "",
 		"Enable telegraf --watch-config flag. Valid values: 'inotify', 'poll'. Default: disabled")
+	flag.Var(&telegrafSecurityRunAsUser, "telegraf-security-run-as-user",
+		"User ID for telegraf sidecar containers")
+	flag.Var(&telegrafSecurityRunAsGroup, "telegraf-security-run-as-group",
+		"Group ID for telegraf sidecar containers")
+	flag.Var(&telegrafSecurityRunAsNonRoot, "telegraf-security-run-as-non-root",
+		"Run telegraf sidecar as non-root user")
+	flag.Var(&telegrafSecurityReadOnlyRootFS, "telegraf-security-readonly-rootfs",
+		"Use read-only root filesystem for telegraf sidecar")
+	flag.Var(&telegrafSecurityAllowPrivEsc, "telegraf-security-allow-privilege-escalation",
+		"Allow privilege escalation for telegraf sidecar")
+	flag.StringVar(&telegrafSecurityCapAdd, "telegraf-security-capabilities-add", "",
+		"Comma-separated list of capabilities to add")
+	flag.StringVar(&telegrafSecurityCapDrop, "telegraf-security-capabilities-drop", "",
+		"Comma-separated list of capabilities to drop")
 	flag.BoolVar(&disableCacheOptimizations, "disable-cache-optimizations", false,
 		"Disable controller-runtime cache optimizations for troubleshooting. "+
 			"When enabled, caches all objects instead of filtering by labels. "+
@@ -243,7 +265,7 @@ func main() {
 				},
 			}
 		}(),
-		Controller: config.Controller{
+		Controller: ctrlCfg.Controller{
 			MaxConcurrentReconciles: 4,
 		},
 	})
@@ -265,14 +287,21 @@ func main() {
 	}
 
 	admission := &injectorwebhook.SidecarInjector{
-		SecretNamePrefix:     telegrafSecretNamePrefix,
-		TelegrafImage:        telegrafImage,
-		RequestsCPU:          telegrafRequestsCPU,
-		RequestsMemory:       telegrafRequestsMemory,
-		LimitsCPU:            telegrafLimitsCPU,
-		LimitsMemory:         telegrafLimitsMemory,
-		EnableNativeSidecars: enableNativeSidecars,
-		WatchConfig:          telegrafWatchConfig,
+		SecretNamePrefix:                 telegrafSecretNamePrefix,
+		TelegrafImage:                    telegrafImage,
+		RequestsCPU:                      telegrafRequestsCPU,
+		RequestsMemory:                   telegrafRequestsMemory,
+		LimitsCPU:                        telegrafLimitsCPU,
+		LimitsMemory:                     telegrafLimitsMemory,
+		EnableNativeSidecars:             enableNativeSidecars,
+		WatchConfig:                      telegrafWatchConfig,
+		SecurityRunAsUser:                &telegrafSecurityRunAsUser,
+		SecurityRunAsGroup:               &telegrafSecurityRunAsGroup,
+		SecurityRunAsNonRoot:             &telegrafSecurityRunAsNonRoot,
+		SecurityReadOnlyRootFilesystem:   &telegrafSecurityReadOnlyRootFS,
+		SecurityAllowPrivilegeEscalation: &telegrafSecurityAllowPrivEsc,
+		SecurityCapabilitiesAdd:          telegrafSecurityCapAdd,
+		SecurityCapabilitiesDrop:         telegrafSecurityCapDrop,
 	}
 
 	if err = admission.SetupWithManager(mgr); err != nil {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 Josh Michielsen.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type OptionalInt64 struct {
+	value *int64
+}
+
+func (o *OptionalInt64) String() string {
+	if o.value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", *o.value)
+}
+
+func (o *OptionalInt64) Set(s string) error {
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	o.value = &v
+	return nil
+}
+
+func (o *OptionalInt64) Value() *int64 {
+	return o.value
+}
+
+type OptionalBool struct {
+	value *bool
+}
+
+func (o *OptionalBool) String() string {
+	if o.value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%t", *o.value)
+}
+
+func (o *OptionalBool) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return err
+	}
+	o.value = &v
+	return nil
+}
+
+func (o *OptionalBool) Value() *bool {
+	return o.value
+}

--- a/internal/injectorwebhook/injector.go
+++ b/internal/injectorwebhook/injector.go
@@ -28,18 +28,26 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/jmickey/telegraf-sidecar-operator/internal/config"
 	"github.com/jmickey/telegraf-sidecar-operator/internal/metadata"
 )
 
 type SidecarInjector struct {
-	SecretNamePrefix     string
-	TelegrafImage        string
-	WatchConfig          string
-	RequestsCPU          string
-	RequestsMemory       string
-	LimitsCPU            string
-	LimitsMemory         string
-	EnableNativeSidecars bool
+	SecretNamePrefix                 string
+	TelegrafImage                    string
+	WatchConfig                      string
+	RequestsCPU                      string
+	RequestsMemory                   string
+	LimitsCPU                        string
+	LimitsMemory                     string
+	EnableNativeSidecars             bool
+	SecurityRunAsUser                *config.OptionalInt64
+	SecurityRunAsGroup               *config.OptionalInt64
+	SecurityRunAsNonRoot             *config.OptionalBool
+	SecurityReadOnlyRootFilesystem   *config.OptionalBool
+	SecurityAllowPrivilegeEscalation *config.OptionalBool
+	SecurityCapabilitiesAdd          string
+	SecurityCapabilitiesDrop         string
 }
 
 //+kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=ignore,groups=core,resources=pods,verbs=create;update,versions=v1,name=telegraf.mickey.dev,sideEffects=none,admissionReviewVersions=v1

--- a/internal/injectorwebhook/injector_test.go
+++ b/internal/injectorwebhook/injector_test.go
@@ -853,15 +853,15 @@ var _ = Describe("Sidecar injector webhook", func() {
 				oldSecurityCapabilitiesDrop := injector.SecurityCapabilitiesDrop
 
 				runAsUser := &config.OptionalInt64{}
-				runAsUser.Set("100")
+				Expect(runAsUser.Set("100")).To(Succeed())
 				runAsGroup := &config.OptionalInt64{}
-				runAsGroup.Set("101")
+				Expect(runAsGroup.Set("101")).To(Succeed())
 				runAsNonRoot := &config.OptionalBool{}
-				runAsNonRoot.Set("true")
+				Expect(runAsNonRoot.Set("true")).To(Succeed())
 				readOnlyRootFilesystem := &config.OptionalBool{}
-				readOnlyRootFilesystem.Set("true")
+				Expect(readOnlyRootFilesystem.Set("true")).To(Succeed())
 				allowPrivilegeEscalation := &config.OptionalBool{}
-				allowPrivilegeEscalation.Set("false")
+				Expect(allowPrivilegeEscalation.Set("false")).To(Succeed())
 
 				injector.SecurityRunAsUser = runAsUser
 				injector.SecurityRunAsGroup = runAsGroup

--- a/internal/injectorwebhook/injector_test.go
+++ b/internal/injectorwebhook/injector_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/jmickey/telegraf-sidecar-operator/internal/config"
 	"github.com/jmickey/telegraf-sidecar-operator/internal/metadata"
 )
 
@@ -835,6 +836,106 @@ var _ = Describe("Sidecar injector webhook", func() {
 						// Requests should still be present
 						Expect(container.Resources.Requests.Cpu().String()).To(Equal(defaultRequestsCPU))
 						Expect(container.Resources.Requests.Memory().String()).To(Equal(defaultRequestsMemory))
+					}
+				}
+				Expect(found).To(BeTrue())
+
+				cleanUpPod(pod.GetName())
+			})
+
+			It("Should apply security context when configured globally", func() {
+				oldSecurityRunAsUser := injector.SecurityRunAsUser
+				oldSecurityRunAsGroup := injector.SecurityRunAsGroup
+				oldSecurityRunAsNonRoot := injector.SecurityRunAsNonRoot
+				oldSecurityReadOnlyRootFilesystem := injector.SecurityReadOnlyRootFilesystem
+				oldSecurityAllowPrivilegeEscalation := injector.SecurityAllowPrivilegeEscalation
+				oldSecurityCapabilitiesAdd := injector.SecurityCapabilitiesAdd
+				oldSecurityCapabilitiesDrop := injector.SecurityCapabilitiesDrop
+
+				runAsUser := &config.OptionalInt64{}
+				runAsUser.Set("100")
+				runAsGroup := &config.OptionalInt64{}
+				runAsGroup.Set("101")
+				runAsNonRoot := &config.OptionalBool{}
+				runAsNonRoot.Set("true")
+				readOnlyRootFilesystem := &config.OptionalBool{}
+				readOnlyRootFilesystem.Set("true")
+				allowPrivilegeEscalation := &config.OptionalBool{}
+				allowPrivilegeEscalation.Set("false")
+
+				injector.SecurityRunAsUser = runAsUser
+				injector.SecurityRunAsGroup = runAsGroup
+				injector.SecurityRunAsNonRoot = runAsNonRoot
+				injector.SecurityReadOnlyRootFilesystem = readOnlyRootFilesystem
+				injector.SecurityAllowPrivilegeEscalation = allowPrivilegeEscalation
+				injector.SecurityCapabilitiesAdd = "NET_RAW"
+				injector.SecurityCapabilitiesDrop = "ALL"
+
+				defer func() {
+					injector.SecurityRunAsUser = oldSecurityRunAsUser
+					injector.SecurityRunAsGroup = oldSecurityRunAsGroup
+					injector.SecurityRunAsNonRoot = oldSecurityRunAsNonRoot
+					injector.SecurityReadOnlyRootFilesystem = oldSecurityReadOnlyRootFilesystem
+					injector.SecurityAllowPrivilegeEscalation = oldSecurityAllowPrivilegeEscalation
+					injector.SecurityCapabilitiesAdd = oldSecurityCapabilitiesAdd
+					injector.SecurityCapabilitiesDrop = oldSecurityCapabilitiesDrop
+				}()
+
+				podName := "sidecar-security-context"
+
+				pod := newTestPod(podName, map[string]string{
+					metadata.TelegrafConfigClassAnnotation: "default",
+				})
+				Expect(k8sClient.Create(testCtx, pod)).To(Succeed())
+
+				pod = &corev1.Pod{}
+				lookupKey := types.NamespacedName{Name: podName, Namespace: namespace}
+				Expect(k8sClient.Get(testCtx, lookupKey, pod)).To(Succeed())
+				Expect(len(pod.Spec.Containers)).To(Equal(2))
+
+				var found bool
+				for _, container := range pod.Spec.Containers {
+					if container.Name == containerName {
+						found = true
+						Expect(container.SecurityContext).NotTo(BeNil())
+						Expect(container.SecurityContext.RunAsUser).NotTo(BeNil())
+						Expect(*container.SecurityContext.RunAsUser).To(Equal(int64(100)))
+						Expect(container.SecurityContext.RunAsGroup).NotTo(BeNil())
+						Expect(*container.SecurityContext.RunAsGroup).To(Equal(int64(101)))
+						Expect(container.SecurityContext.RunAsNonRoot).NotTo(BeNil())
+						Expect(*container.SecurityContext.RunAsNonRoot).To(BeTrue())
+						Expect(container.SecurityContext.ReadOnlyRootFilesystem).NotTo(BeNil())
+						Expect(*container.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+						Expect(container.SecurityContext.AllowPrivilegeEscalation).NotTo(BeNil())
+						Expect(*container.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+						Expect(container.SecurityContext.Capabilities).NotTo(BeNil())
+						Expect(container.SecurityContext.Capabilities.Add).To(ContainElement(corev1.Capability("NET_RAW")))
+						Expect(container.SecurityContext.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+					}
+				}
+				Expect(found).To(BeTrue())
+
+				cleanUpPod(pod.GetName())
+			})
+
+			It("Should not apply security context when not configured", func() {
+				podName := "sidecar-no-security-context"
+
+				pod := newTestPod(podName, map[string]string{
+					metadata.TelegrafConfigClassAnnotation: "default",
+				})
+				Expect(k8sClient.Create(testCtx, pod)).To(Succeed())
+
+				pod = &corev1.Pod{}
+				lookupKey := types.NamespacedName{Name: podName, Namespace: namespace}
+				Expect(k8sClient.Get(testCtx, lookupKey, pod)).To(Succeed())
+				Expect(len(pod.Spec.Containers)).To(Equal(2))
+
+				var found bool
+				for _, container := range pod.Spec.Containers {
+					if container.Name == containerName {
+						found = true
+						Expect(container.SecurityContext).To(BeNil())
 					}
 				}
 				Expect(found).To(BeTrue())

--- a/internal/injectorwebhook/sidecar.go
+++ b/internal/injectorwebhook/sidecar.go
@@ -34,16 +34,17 @@ const (
 )
 
 type containerConfig struct {
-	image          string
-	debug          bool
-	watchConfig    string
-	requestsCPU    resource.Quantity
-	requestsMemory resource.Quantity
-	limitsCPU      resource.Quantity
-	limitsMemory   resource.Quantity
-	env            []corev1.EnvVar
-	envFrom        []corev1.EnvFromSource
-	volumeMounts   []corev1.VolumeMount
+	image           string
+	debug           bool
+	watchConfig     string
+	requestsCPU     resource.Quantity
+	requestsMemory  resource.Quantity
+	limitsCPU       resource.Quantity
+	limitsMemory    resource.Quantity
+	env             []corev1.EnvVar
+	envFrom         []corev1.EnvFromSource
+	volumeMounts    []corev1.VolumeMount
+	securityContext *corev1.SecurityContext
 }
 
 func newContainerConfig(s *SidecarInjector) (*containerConfig, error) {
@@ -95,6 +96,8 @@ func newContainerConfig(s *SidecarInjector) (*containerConfig, error) {
 	if c.limitsMemory, err = resource.ParseQuantity(s.LimitsMemory); err != nil {
 		return nil, fmt.Errorf("failed to parse memory limits with value: %s, error: %w", s.LimitsMemory, err)
 	}
+
+	c.securityContext = buildSecurityContext(s)
 
 	return c, nil
 }
@@ -290,12 +293,13 @@ func (c *containerConfig) buildContainerSpec() corev1.Container {
 	}
 
 	container := corev1.Container{
-		Name:      containerName,
-		Image:     c.image,
-		Command:   command,
-		Resources: resourceRequirements,
-		Env:       c.env,
-		EnvFrom:   c.envFrom,
+		Name:            containerName,
+		Image:           c.image,
+		Command:         command,
+		Resources:       resourceRequirements,
+		Env:             c.env,
+		EnvFrom:         c.envFrom,
+		SecurityContext: c.securityContext,
 		VolumeMounts: append(c.volumeMounts, corev1.VolumeMount{
 			Name:      fmt.Sprintf("%s-config", containerName),
 			MountPath: "/etc/telegraf",
@@ -303,4 +307,46 @@ func (c *containerConfig) buildContainerSpec() corev1.Container {
 	}
 
 	return container
+}
+
+func buildSecurityContext(s *SidecarInjector) *corev1.SecurityContext {
+	if s.SecurityRunAsUser.Value() == nil &&
+		s.SecurityRunAsGroup.Value() == nil &&
+		s.SecurityRunAsNonRoot.Value() == nil &&
+		s.SecurityReadOnlyRootFilesystem.Value() == nil &&
+		s.SecurityAllowPrivilegeEscalation.Value() == nil &&
+		s.SecurityCapabilitiesAdd == "" &&
+		s.SecurityCapabilitiesDrop == "" {
+		return nil
+	}
+
+	sc := &corev1.SecurityContext{
+		RunAsUser:                s.SecurityRunAsUser.Value(),
+		RunAsGroup:               s.SecurityRunAsGroup.Value(),
+		RunAsNonRoot:             s.SecurityRunAsNonRoot.Value(),
+		ReadOnlyRootFilesystem:   s.SecurityReadOnlyRootFilesystem.Value(),
+		AllowPrivilegeEscalation: s.SecurityAllowPrivilegeEscalation.Value(),
+	}
+
+	if s.SecurityCapabilitiesAdd != "" || s.SecurityCapabilitiesDrop != "" {
+		sc.Capabilities = &corev1.Capabilities{}
+		if s.SecurityCapabilitiesAdd != "" {
+			caps := strings.Split(s.SecurityCapabilitiesAdd, ",")
+			capList := make([]corev1.Capability, len(caps))
+			for i, cap := range caps {
+				capList[i] = corev1.Capability(strings.TrimSpace(cap))
+			}
+			sc.Capabilities.Add = capList
+		}
+		if s.SecurityCapabilitiesDrop != "" {
+			caps := strings.Split(s.SecurityCapabilitiesDrop, ",")
+			capList := make([]corev1.Capability, len(caps))
+			for i, cap := range caps {
+				capList[i] = corev1.Capability(strings.TrimSpace(cap))
+			}
+			sc.Capabilities.Drop = capList
+		}
+	}
+
+	return sc
 }

--- a/internal/injectorwebhook/webhook_suite_test.go
+++ b/internal/injectorwebhook/webhook_suite_test.go
@@ -41,6 +41,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/jmickey/telegraf-sidecar-operator/internal/config"
 )
 
 var cfg *rest.Config
@@ -120,13 +122,20 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	injector = &SidecarInjector{
-		SecretNamePrefix:     "telegraf",
-		TelegrafImage:        defaultTelegrafImage,
-		RequestsCPU:          defaultRequestsCPU,
-		RequestsMemory:       defaultRequestsMemory,
-		LimitsCPU:            defaultLimitsCPU,
-		LimitsMemory:         defaultLimitsMemory,
-		EnableNativeSidecars: false,
+		SecretNamePrefix:                 "telegraf",
+		TelegrafImage:                    defaultTelegrafImage,
+		RequestsCPU:                      defaultRequestsCPU,
+		RequestsMemory:                   defaultRequestsMemory,
+		LimitsCPU:                        defaultLimitsCPU,
+		LimitsMemory:                     defaultLimitsMemory,
+		EnableNativeSidecars:             false,
+		SecurityRunAsUser:                &config.OptionalInt64{},
+		SecurityRunAsGroup:               &config.OptionalInt64{},
+		SecurityRunAsNonRoot:             &config.OptionalBool{},
+		SecurityReadOnlyRootFilesystem:   &config.OptionalBool{},
+		SecurityAllowPrivilegeEscalation: &config.OptionalBool{},
+		SecurityCapabilitiesAdd:          "",
+		SecurityCapabilitiesDrop:         "",
 	}
 
 	err = injector.SetupWithManager(mgr)


### PR DESCRIPTION
Add platform-level security context configuration via command-line flags. Supports runAsUser, runAsGroup, runAsNonRoot, readOnlyRootFilesystem, allowPrivilegeEscalation, and Linux capabilities configuration.

No defaults provided - security context only applied when explicitly configured.

Closes: #105