### PR TITLE
feat: add aggregator and processor annotations behind feature gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Pod annotations can be used to configure both the sidecar container itself, as w
 | `telegraf.influxdata.com/metric-version`           | `"1"`               | Can be used to override which metrics parsing version to use. Valid values are [ `"1"`, `"2"`].                                                                                                                                                                                                             |
 | `telegraf.influxdata.com/namepass`                 | `nil`               | Can be used to configure the namepass setting for the Prometheus input plugin. Namepass accepts an array of glob pattern strings. Only metrics whose measurement name matches a pattern in this list are emitted. Annotation value must be specified as a comma-separated string, e.g. `"metric1, metric2"` |
 | `telegraf.influxdata.com/inputs`                   | `nil`               | Can be used to configure a raw telegraf input TOML block. Can be provided as a multiline block of raw TOML configuration.                                                                                                                                                                   |
+| `telegraf.influxdata.com/aggregators`              | `nil`               | Can be used to configure raw telegraf aggregator TOML blocks. Can be provided as a multiline block of raw TOML configuration. **Requires the `telegraf.aggregators` feature gate to be enabled.**                                                                                          |
+| `telegraf.influxdata.com/processors`               | `nil`               | Can be used to configure raw telegraf processor TOML blocks. Can be provided as a multiline block of raw TOML configuration. **Requires the `telegraf.processors` feature gate to be enabled.**                                                                                            |
 | `telegraf.influxdata.com/internal`                 | Configured globally | Enables the "internal" telegraf plugin if it is configured to be globally disabled by default. Any non-empty string value is accepted.                                                                                                                                                      |
 | `telegraf.influxdata.com/debug`                    | `false`             | Enables debug logging in the telegraf sidecar container. Set to `"true"` to enable verbose debug output for troubleshooting. This adds the `--debug` flag to the telegraf command.                                                                                                        |
 | `telegraf.influxdata.com/global-tag-literal-<KEY>` | `nil`               | Can be used to add a literal value to the global_tags in the telegraf configuration.                                                                                                                                                                                                        |
@@ -216,6 +218,17 @@ spec:
         telegraf.influxdata.com/debug: "true" # Enable debug logging for troubleshooting
         telegraf.influxdata.com/env-fieldref-APP: metadata.labels['app']
         telegraf.influxdata.com/global-tag-literal-app: "$APP"
+        # Feature gated annotations (require --feature-gates flag)
+        telegraf.influxdata.com/aggregators: |
+          [[aggregators.basicstats]]
+            period = "30s"
+            stats = ["count", "sum", "mean"]
+        telegraf.influxdata.com/processors: |
+          [[processors.regex]]
+            [[processors.regex.tags]]
+              key = "service"
+              pattern = "^([^-]*)-.*"
+              replacement = "${1}"
       # ...
 ```
 

--- a/config/testdata/fixtures/aggregator-enabled.toml
+++ b/config/testdata/fixtures/aggregator-enabled.toml
@@ -1,0 +1,31 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "10s"
+  flush_jitter = "3s"
+  hostname = "$NODENAME"
+  interval = "10s"
+  logfile = ""
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  quiet = false
+  round_interval = true
+
+[inputs]
+
+[outputs]
+
+  [[outputs.file]]
+    files = ["stdout"]
+
+[aggregators]
+
+  [[aggregators.basicstats]]
+    period = "30s"
+    stats = ["count", "sum", "mean"]
+
+[global_tags]
+  namespace = "$NAMESPACE"
+  nodename = "$NODENAME"
+  pod_name = "$HOSTNAME"
+  type = "app"

--- a/config/testdata/fixtures/both-features-enabled.toml
+++ b/config/testdata/fixtures/both-features-enabled.toml
@@ -1,0 +1,45 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "10s"
+  flush_jitter = "3s"
+  hostname = "$NODENAME"
+  interval = "10s"
+  logfile = ""
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  quiet = false
+  round_interval = true
+
+[inputs]
+
+  [[inputs.prometheus]]
+    interval = "10s"
+    urls = ["http://localhost:8080/metrics"]
+    metric_version = 1
+
+[outputs]
+
+  [[outputs.file]]
+    files = ["stdout"]
+
+[aggregators]
+
+  [[aggregators.basicstats]]
+    period = "30s"
+    stats = ["count", "sum", "mean"]
+
+[processors]
+
+  [[processors.regex]]
+
+    [[processors.regex.tags]]
+      key = "service"
+      pattern = "^([^-]*)-.*"
+      replacement = "${1}"
+
+[global_tags]
+  namespace = "$NAMESPACE"
+  nodename = "$NODENAME"
+  pod_name = "$HOSTNAME"
+  type = "app"

--- a/config/testdata/fixtures/processor-enabled.toml
+++ b/config/testdata/fixtures/processor-enabled.toml
@@ -1,0 +1,34 @@
+[agent]
+  collection_jitter = "0s"
+  debug = false
+  flush_interval = "10s"
+  flush_jitter = "3s"
+  hostname = "$NODENAME"
+  interval = "10s"
+  logfile = ""
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  quiet = false
+  round_interval = true
+
+[inputs]
+
+[outputs]
+
+  [[outputs.file]]
+    files = ["stdout"]
+
+[processors]
+
+  [[processors.regex]]
+
+    [[processors.regex.tags]]
+      key = "service"
+      pattern = "^([^-]*)-.*"
+      replacement = "${1}"
+
+[global_tags]
+  namespace = "$NAMESPACE"
+  nodename = "$NODENAME"
+  pod_name = "$HOSTNAME"
+  type = "app"

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/jmickey/telegraf-sidecar-operator/internal/featuregate"
 	"github.com/jmickey/telegraf-sidecar-operator/internal/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -444,6 +445,259 @@ var _ = Describe("Pod Controller", func() {
 					}, duration, interval).Should(BeTrue())
 
 					cleanUpPod(pod.GetName())
+				})
+			})
+
+			Context("With aggregator annotations feature gate", func() {
+				BeforeEach(func() {
+					err := featuregate.Set("telegraf.aggregators", true)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				AfterEach(func() {
+					err := featuregate.Set("telegraf.aggregators", false)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				It("Should reconcile successfully with aggregator annotation when feature gate is enabled", func() {
+					pod := newTestPod(
+						"aggregator-enabled",
+						map[string]string{
+							metadata.SidecarInjectedLabel:   "true",
+							metadata.SidecarSecretNameLabel: "telegraf-config-aggregator-enabled",
+						},
+						map[string]string{
+							metadata.TelegrafConfigRawAggregatorsAnnotation: `
+								[[aggregators.basicstats]]
+									period = "30s"
+									stats = ["count", "sum", "mean"]
+							`,
+						},
+					)
+					Expect(k8sClient.Create(testCtx, pod)).Should(Succeed())
+					Eventually(func() error {
+						p := &corev1.Pod{}
+						key := types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}
+						return k8sClient.Get(testCtx, key, p)
+					}, timeout, interval).Should(Succeed())
+
+					secret := &corev1.Secret{}
+					Eventually(func() error {
+						key := types.NamespacedName{
+							Name:      pod.GetLabels()[metadata.SidecarSecretNameLabel],
+							Namespace: pod.GetNamespace(),
+						}
+						return k8sClient.Get(testCtx, key, secret)
+					}, timeout, interval).Should(Succeed())
+
+					fixture, err := os.ReadFile("../../config/testdata/fixtures/aggregator-enabled.toml")
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(string(secret.Data["telegraf.conf"])).Should(Equal(string(fixture)))
+
+					cleanUpPod(pod.GetName())
+					cleanUpSecret(secret.GetName())
+				})
+
+				It("Should not include aggregator config when feature gate is disabled", func() {
+					err := featuregate.Set("telegraf.aggregators", false)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					pod := newTestPod(
+						"aggregator-disabled",
+						map[string]string{
+							metadata.SidecarInjectedLabel:   "true",
+							metadata.SidecarSecretNameLabel: "telegraf-config-aggregator-disabled",
+						},
+						map[string]string{
+							metadata.TelegrafConfigRawAggregatorsAnnotation: `
+								[[aggregators.basicstats]]
+									period = "30s"
+									stats = ["count", "sum", "mean"]
+							`,
+						},
+					)
+					Expect(k8sClient.Create(testCtx, pod)).Should(Succeed())
+					Eventually(func() error {
+						p := &corev1.Pod{}
+						key := types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}
+						return k8sClient.Get(testCtx, key, p)
+					}, timeout, interval).Should(Succeed())
+
+					secret := &corev1.Secret{}
+					Eventually(func() error {
+						key := types.NamespacedName{
+							Name:      pod.GetLabels()[metadata.SidecarSecretNameLabel],
+							Namespace: pod.GetNamespace(),
+						}
+						return k8sClient.Get(testCtx, key, secret)
+					}, timeout, interval).Should(Succeed())
+
+					fixture, err := os.ReadFile("../../config/testdata/fixtures/minimum-config.toml")
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(string(secret.Data["telegraf.conf"])).Should(Equal(string(fixture)))
+
+					cleanUpPod(pod.GetName())
+					cleanUpSecret(secret.GetName())
+				})
+			})
+
+			Context("With processor annotations feature gate", func() {
+				BeforeEach(func() {
+					err := featuregate.Set("telegraf.processors", true)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				AfterEach(func() {
+					err := featuregate.Set("telegraf.processors", false)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				It("Should reconcile successfully with processor annotation when feature gate is enabled", func() {
+					pod := newTestPod(
+						"processor-enabled",
+						map[string]string{
+							metadata.SidecarInjectedLabel:   "true",
+							metadata.SidecarSecretNameLabel: "telegraf-config-processor-enabled",
+						},
+						map[string]string{
+							metadata.TelegrafConfigRawProcessorsAnnotation: `
+								[[processors.regex]]
+									[[processors.regex.tags]]
+										key = "service"
+										pattern = "^([^-]*)-.*"
+										replacement = "${1}"
+							`,
+						},
+					)
+					Expect(k8sClient.Create(testCtx, pod)).Should(Succeed())
+					Eventually(func() error {
+						p := &corev1.Pod{}
+						key := types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}
+						return k8sClient.Get(testCtx, key, p)
+					}, timeout, interval).Should(Succeed())
+
+					secret := &corev1.Secret{}
+					Eventually(func() error {
+						key := types.NamespacedName{
+							Name:      pod.GetLabels()[metadata.SidecarSecretNameLabel],
+							Namespace: pod.GetNamespace(),
+						}
+						return k8sClient.Get(testCtx, key, secret)
+					}, timeout, interval).Should(Succeed())
+
+					fixture, err := os.ReadFile("../../config/testdata/fixtures/processor-enabled.toml")
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(string(secret.Data["telegraf.conf"])).Should(Equal(string(fixture)))
+
+					cleanUpPod(pod.GetName())
+					cleanUpSecret(secret.GetName())
+				})
+
+				It("Should not include processor config when feature gate is disabled", func() {
+					err := featuregate.Set("telegraf.processors", false)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					pod := newTestPod(
+						"processor-disabled",
+						map[string]string{
+							metadata.SidecarInjectedLabel:   "true",
+							metadata.SidecarSecretNameLabel: "telegraf-config-processor-disabled",
+						},
+						map[string]string{
+							metadata.TelegrafConfigRawProcessorsAnnotation: `
+								[[processors.regex]]
+									[[processors.regex.tags]]
+										key = "service"
+										pattern = "^([^-]*)-.*"
+										replacement = "${1}"
+							`,
+						},
+					)
+					Expect(k8sClient.Create(testCtx, pod)).Should(Succeed())
+					Eventually(func() error {
+						p := &corev1.Pod{}
+						key := types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}
+						return k8sClient.Get(testCtx, key, p)
+					}, timeout, interval).Should(Succeed())
+
+					secret := &corev1.Secret{}
+					Eventually(func() error {
+						key := types.NamespacedName{
+							Name:      pod.GetLabels()[metadata.SidecarSecretNameLabel],
+							Namespace: pod.GetNamespace(),
+						}
+						return k8sClient.Get(testCtx, key, secret)
+					}, timeout, interval).Should(Succeed())
+
+					fixture, err := os.ReadFile("../../config/testdata/fixtures/minimum-config.toml")
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(string(secret.Data["telegraf.conf"])).Should(Equal(string(fixture)))
+
+					cleanUpPod(pod.GetName())
+					cleanUpSecret(secret.GetName())
+				})
+			})
+
+			Context("With both aggregator and processor feature gates enabled", func() {
+				BeforeEach(func() {
+					err := featuregate.Set("telegraf.aggregators", true)
+					Expect(err).ShouldNot(HaveOccurred())
+					err = featuregate.Set("telegraf.processors", true)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				AfterEach(func() {
+					err := featuregate.Set("telegraf.aggregators", false)
+					Expect(err).ShouldNot(HaveOccurred())
+					err = featuregate.Set("telegraf.processors", false)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				It("Should reconcile successfully with both aggregator and processor annotations", func() {
+					pod := newTestPod(
+						"both-features-enabled",
+						map[string]string{
+							metadata.SidecarInjectedLabel:   "true",
+							metadata.SidecarSecretNameLabel: "telegraf-config-both-features-enabled",
+						},
+						map[string]string{
+							metadata.TelegrafConfigMetricsPortsAnnotation: "8080",
+							metadata.TelegrafConfigRawAggregatorsAnnotation: `
+								[[aggregators.basicstats]]
+									period = "30s"
+									stats = ["count", "sum", "mean"]
+							`,
+							metadata.TelegrafConfigRawProcessorsAnnotation: `
+								[[processors.regex]]
+									[[processors.regex.tags]]
+										key = "service"
+										pattern = "^([^-]*)-.*"
+										replacement = "${1}"
+							`,
+						},
+					)
+					Expect(k8sClient.Create(testCtx, pod)).Should(Succeed())
+					Eventually(func() error {
+						p := &corev1.Pod{}
+						key := types.NamespacedName{Name: pod.GetName(), Namespace: pod.GetNamespace()}
+						return k8sClient.Get(testCtx, key, p)
+					}, timeout, interval).Should(Succeed())
+
+					secret := &corev1.Secret{}
+					Eventually(func() error {
+						key := types.NamespacedName{
+							Name:      pod.GetLabels()[metadata.SidecarSecretNameLabel],
+							Namespace: pod.GetNamespace(),
+						}
+						return k8sClient.Get(testCtx, key, secret)
+					}, timeout, interval).Should(Succeed())
+
+					fixture, err := os.ReadFile("../../config/testdata/fixtures/both-features-enabled.toml")
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(string(secret.Data["telegraf.conf"])).Should(Equal(string(fixture)))
+
+					cleanUpPod(pod.GetName())
+					cleanUpSecret(secret.GetName())
 				})
 			})
 		})

--- a/internal/controller/telegraf.go
+++ b/internal/controller/telegraf.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/jmickey/telegraf-sidecar-operator/internal/classdata"
+	"github.com/jmickey/telegraf-sidecar-operator/internal/featuregate"
 	"github.com/jmickey/telegraf-sidecar-operator/internal/metadata"
 )
 
@@ -40,6 +41,8 @@ type annotationValues struct {
 	scheme           string
 	namepass         string
 	rawInput         string
+	rawAggregators   string
+	rawProcessors    string
 	ports            []uint16
 	interval         time.Duration
 	metricVersion    uint8
@@ -79,6 +82,8 @@ func newAnnotationValues(classDataHandler classdata.Handler, class string, enabl
 		interval:         defaultInterval,
 		enableInternal:   enableInternal,
 		rawInput:         "",
+		rawAggregators:   "",
+		rawProcessors:    "",
 		globalTags:       make(map[string]string),
 	}
 }
@@ -161,6 +166,14 @@ func (c *annotationValues) applyAnnotationOverrides(annotations map[string]strin
 		c.rawInput = override
 	}
 
+	if override, ok := annotations[metadata.TelegrafConfigRawAggregatorsAnnotation]; ok {
+		c.rawAggregators = override
+	}
+
+	if override, ok := annotations[metadata.TelegrafConfigRawProcessorsAnnotation]; ok {
+		c.rawProcessors = override
+	}
+
 	c.globalTags = metadata.GetAnnotationsWithPrefix(annotations,
 		metadata.TelegrafConfigGlobalTagLiteralPrefixAnnotation)
 
@@ -219,6 +232,42 @@ func (c *annotationValues) buildConfigData() (string, error) {
 
 		for k, v := range rawInputs.Inputs {
 			cfg.Inputs[k] = v
+		}
+	}
+
+	if c.rawAggregators != "" && featuregate.AggregatorAnnotations.IsEnabled() {
+		type rawAggregators struct {
+			Aggregators map[string]any `toml:"aggregators"`
+		}
+
+		rawAggs := rawAggregators{}
+		if err := toml.Unmarshal([]byte(strings.TrimSpace(c.rawAggregators)), &rawAggs); err != nil {
+			return "", fmt.Errorf("failed to unmarshal raw aggregators annotation data, error: %w", err)
+		}
+
+		if cfg.Aggregators == nil {
+			cfg.Aggregators = make(map[string]any)
+		}
+		for k, v := range rawAggs.Aggregators {
+			cfg.Aggregators[k] = v
+		}
+	}
+
+	if c.rawProcessors != "" && featuregate.ProcessorAnnotations.IsEnabled() {
+		type rawProcessors struct {
+			Processors map[string]any `toml:"processors"`
+		}
+
+		rawProcs := rawProcessors{}
+		if err := toml.Unmarshal([]byte(strings.TrimSpace(c.rawProcessors)), &rawProcs); err != nil {
+			return "", fmt.Errorf("failed to unmarshal raw processors annotation data, error: %w", err)
+		}
+
+		if cfg.Processors == nil {
+			cfg.Processors = make(map[string]any)
+		}
+		for k, v := range rawProcs.Processors {
+			cfg.Processors[k] = v
 		}
 	}
 

--- a/internal/featuregate/gates.go
+++ b/internal/featuregate/gates.go
@@ -24,3 +24,19 @@ package featuregate
 var NativeSidecars = Register("operator.nativesidecars",
 	"Use Kubernetes 1.28+ native sidecar containers instead of regular containers",
 	false)
+
+// AggregatorAnnotations enables telegraf aggregator plugin configuration via pod annotations.
+//
+// When enabled, pods can use the telegraf.influxdata.com/aggregators annotation
+// to specify raw TOML configuration for aggregator plugins.
+var AggregatorAnnotations = Register("telegraf.aggregators",
+	"Enable telegraf aggregator plugin configuration via pod annotations",
+	false)
+
+// ProcessorAnnotations enables telegraf processor plugin configuration via pod annotations.
+//
+// When enabled, pods can use the telegraf.influxdata.com/processors annotation
+// to specify raw TOML configuration for processor plugins.
+var ProcessorAnnotations = Register("telegraf.processors",
+	"Enable telegraf processor plugin configuration via pod annotations",
+	false)

--- a/internal/metadata/annotations.go
+++ b/internal/metadata/annotations.go
@@ -139,6 +139,30 @@ const (
 	//     servers = ["tcp://localhost:6379"]
 	TelegrafConfigRawInputAnnotation = Prefix + "/inputs"
 
+	// TelegrafConfigRawAggregatorsAnnotation can be used to configure
+	// raw telegraf aggregator TOML blocks. Can be provided as a multiline
+	// block of raw TOML configuration. Requires the telegraf.aggregators
+	// feature gate to be enabled.
+	// e.g.
+	// telegraf.influxdata.com/aggregators: |+
+	//   [[aggregators.basicstats]]
+	//     period = "30s"
+	//     stats = ["count", "sum", "mean"]
+	TelegrafConfigRawAggregatorsAnnotation = Prefix + "/aggregators"
+
+	// TelegrafConfigRawProcessorsAnnotation can be used to configure
+	// raw telegraf processor TOML blocks. Can be provided as a multiline
+	// block of raw TOML configuration. Requires the telegraf.processors
+	// feature gate to be enabled.
+	// e.g.
+	// telegraf.influxdata.com/processors: |+
+	//   [[processors.regex]]
+	//     [[processors.regex.tags]]
+	//       key = "service"
+	//       pattern = "^([^-]*)-.*"
+	//       replacement = "${1}"
+	TelegrafConfigRawProcessorsAnnotation = Prefix + "/processors"
+
 	// TelegrafConfigEnableInternalAnnotation enables the "internal"
 	// telegraf plugin. Any non-empty string value is accepted.
 	TelegrafConfigEnableInternalAnnotation = Prefix + "/internal"


### PR DESCRIPTION
Implement support for telegraf aggregator and processor plugin configuration via pod annotations, controlled by feature gates for safe experimental rollout.

- Add telegraf.aggregators and telegraf.processors feature gates (disabled by default)
- Add telegraf.influxdata.com/aggregators annotation for raw aggregator TOML blocks
- Add telegraf.influxdata.com/processors annotation for raw processor TOML blocks
- Extend controller logic to parse and apply feature-gated annotations
- Add comprehensive BDD-style tests with proper TOML fixtures

Feature gates provide safe experimental functionality that teams can enable when ready, with full backwards compatibility when disabled.

Usage: --feature-gates=telegraf.aggregators,telegraf.processors

Closes #174